### PR TITLE
Fix fee calculation when amount = threshold

### DIFF
--- a/PaystackFees.js
+++ b/PaystackFees.js
@@ -208,7 +208,7 @@ class PaystackFees {
                     .required(),
             }),
         );
-        const flat = amountInLowerDenomination > this.threshold ? this.additionalCharge : 0;
+        const flat = amountInLowerDenomination >= this.threshold ? this.additionalCharge : 0;
         const fees = Math.ceil(this.percentage * amountInLowerDenomination + flat);
         return Math.min(fees, this.cap);
     }


### PR DESCRIPTION
This should be threshold inclusive according to the pricing page.
https://paystack.com/pricing

<img src='https://user-images.githubusercontent.com/21363042/227784904-410b513d-3b16-4e5b-b9eb-67c5dea43642.png' width='300px'/>

<img src='https://user-images.githubusercontent.com/21363042/227785027-47137a37-12a1-4f60-88f3-47128111ab11.png' width='300px'/>

